### PR TITLE
Update edrc.yml

### DIFF
--- a/edrc.yml
+++ b/edrc.yml
@@ -1,9 +1,7 @@
 version: 1
-edrc:
+eagle:
   drc:
     - file: "hardware/comms_module/Communications Board - Top.brd"
       dru: "oshpark-4layer"
     - file: "hardware/comms_module/Communications Board Fake - Bottom.brd"
       dru: "oshpark-2layer"
-  erc:
-    - "hardware/comms_module/Communications Board.sch"


### PR DESCRIPTION
The top level field is no longer `edrc` but `eagle` for forward compatibility. We also don't do anything with `erc`.